### PR TITLE
configure cpu core count on qemu

### DIFF
--- a/spread/project.go
+++ b/spread/project.go
@@ -57,7 +57,8 @@ type Backend struct {
 	Discard  string
 
 	// Only for qemu so far.
-	Memory Size
+	Memory   Size
+	CpuCores int `yaml:"cpu-cores"'`
 
 	// Only for Linode, Google, OpenStack so far.
 	Plan     string

--- a/spread/qemu_test.go
+++ b/spread/qemu_test.go
@@ -77,7 +77,7 @@ func (s *qemuSuite) TestQemuCmdWithEfi(c *C) {
 			Backend: "qemu",
 			Bios:    tc.BiosSetting,
 		}
-		cmd, err := spread.QemuCmd(ms, "/path/to/image", 512, 9999)
+		cmd, err := spread.QemuCmd(ms, "/path/to/image", 512, 9999, 1)
 		if tc.expectedErr == "" {
 			c.Assert(err, IsNil)
 		} else {


### PR DESCRIPTION
QEMU defaults to using all available cores for execution. Add the option to restrict the CPU count to emulate less powerful devices. 